### PR TITLE
Prevent xz warning for 'Cannot set the file group: Operation not permitted'

### DIFF
--- a/beagleboard.org_image.sh
+++ b/beagleboard.org_image.sh
@@ -46,6 +46,8 @@ post_generic_img () {
 
 compress_img () {
         if [ -f \${wfile} ] ; then
+                #prevent xz warning for 'Cannot set the file group: Operation not permitted'
+                sudo chown \${UID}:\${GROUPS} \${wfile}
                 ${archive} \${wfile}
         fi
 }


### PR DESCRIPTION
Stops an warning from xz when run as a non-root user.