### PR TITLE
Don't remove extra home directories indiscriminately

### DIFF
--- a/scripts/chroot.sh
+++ b/scripts/chroot.sh
@@ -1077,15 +1077,6 @@ if [ -d ${tempdir}/etc/ssh/ -a "x${keep_ssh_keys}" = "x" ] ; then
 	sudo touch ${tempdir}/etc/ssh/ssh.regenerate || true
 fi
 
-#extra home, from chroot machine when running npm install xyz:
-unset extra_home
-extra_home=$(ls -lh ${tempdir}/home/ | grep -v ${rfs_username} | awk '{print $9}' | tail -1 || true)
-if [ ! "x${extra_home}" = "x" ] ; then
-	if [ -d ${tempdir}/home/${extra_home}/ ] ; then
-		sudo rm -rf ${tempdir}/home/${extra_home}/ || true
-	fi
-fi
-
 #ID.txt:
 if [ -f ${tempdir}/etc/dogtag ] ; then
 	sudo cp ${tempdir}/etc/dogtag ${DIR}/deploy/${export_filename}/ID.txt


### PR DESCRIPTION
Deleting code that removes home directories indiscriminately. This was removing a service's home directory created by an installed deb, which was a hard bug to track down.

Instead, maybe this can happen somewhere like `install_node_pkgs()` in the `chroot_script`, where there will be more info about which directory needs to be removed. We don't use NPM so I don't know what the problem directory looks like.