### PR TITLE
Make build system more configurable

### DIFF
--- a/RootStock-NG.sh
+++ b/RootStock-NG.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 #
 # Copyright (c) 2013 Robert Nelson <robertcnelson@gmail.com>
 #
@@ -75,8 +75,8 @@ run_roostock_ng () {
 	fi
 
 	/bin/bash -e "${OIB_DIR}/scripts/install_dependencies.sh" || { exit 1 ; }
-	/bin/sh -e "${OIB_DIR}/scripts/debootstrap.sh" || { exit 1 ; }
-	/bin/sh -e "${OIB_DIR}/scripts/chroot.sh" || { exit 1 ; }
+	/bin/bash -e "${OIB_DIR}/scripts/debootstrap.sh" || { exit 1 ; }
+	/bin/bash -e "${OIB_DIR}/scripts/chroot.sh" || { exit 1 ; }
 	sudo rm -rf ${tempdir}/ || true
 }
 

--- a/scripts/debootstrap.sh
+++ b/scripts/debootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 #
 # Copyright (c) 2012-2016 Robert Nelson <robertcnelson@gmail.com>
 #

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -44,7 +44,7 @@ debootstrap_is_installed () {
 }
 
 debootstrap_what_version () {
-	test_debootstrap=$(/usr/sbin/debootstrap --version | awk '{print $2}' | awk -F"." '{print $3}')
+	test_debootstrap=$(/usr/sbin/debootstrap --version | cut -f3 -d.)
 	echo "Log: debootstrap version: 1.0.$test_debootstrap"
 }
 
@@ -52,7 +52,7 @@ debootstrap_is_installed
 debootstrap_what_version
 
 #if [[ "$test_debootstrap" < "$minimal_debootstrap" ]] ; then
-if [ ! "x$test_debootstrap" = "x$minimal_debootstrap" ] ; then
+if [ "$test_debootstrap" -lt "$minimal_debootstrap" ] ; then
 	echo "Log: Installing minimal debootstrap version: 1.0.${minimal_debootstrap}..."
 	wget https://rcn-ee.com/mirror/debootstrap/debootstrap_1.0.${minimal_debootstrap}_all.deb
 	sudo dpkg -i debootstrap_1.0.${minimal_debootstrap}_all.deb

--- a/tools/setup_sdcard.sh
+++ b/tools/setup_sdcard.sh
@@ -1128,9 +1128,9 @@ populate_rootfs () {
 		cmdline="${cmdline} init=/lib/systemd/systemd"
 	fi
 
-	if [ "x${conf_board}" = "xam335x_boneblack" ] || [ "x${conf_board}" = "xam335x_evm" ] ; then
-		cmdline="${cmdline} cape_universal=enable"
-	fi
+	#if [ "x${conf_board}" = "xam335x_boneblack" ] || [ "x${conf_board}" = "xam335x_evm" ] ; then
+	#	cmdline="${cmdline} cape_universal=enable"
+	#fi
 
 	unset kms_video
 
@@ -1264,8 +1264,7 @@ populate_rootfs () {
 		echo "# The primary network interface" >> ${wfile}
 
 		if [ "${DISABLE_ETH}" ] ; then
-			echo "#auto eth0" >> ${wfile}
-			echo "#iface eth0 inet dhcp" >> ${wfile}
+			echo "#${DISABLE_ETH}" >> ${wfile}
 		else
 			echo "auto eth0"  >> ${wfile}
 			echo "iface eth0 inet dhcp" >> ${wfile}
@@ -1303,11 +1302,12 @@ populate_rootfs () {
 
 		echo "# Ethernet/RNDIS gadget (g_ether)" >> ${wfile}
 		echo "# Used by: /opt/scripts/boot/autoconfigure_usb0.sh" >> ${wfile}
+		echo "auto usb0" >> ${wfile}
+		echo "allow-hotplug usb0" >> ${wfile}
 		echo "iface usb0 inet static" >> ${wfile}
 		echo "    address 192.168.7.2" >> ${wfile}
 		echo "    netmask 255.255.255.252" >> ${wfile}
 		echo "    network 192.168.7.0" >> ${wfile}
-		echo "    gateway 192.168.7.1" >> ${wfile}
 
 		if [ -f ${TEMPDIR}/disk/var/www/index.html ] ; then
 			rm -f ${TEMPDIR}/disk/var/www/index.html || true


### PR DESCRIPTION
I'm using this system to build my own images, and needed some changes. This pull request contains three commits which allow me to build my own images without further editing of the sources.

"Support for flat repositories" allows repositories with a "flat" layout, such as the ones locally hosted by mini-dinstall.  I have such a repository, and want to include local packages in my build.  Because I need more than one (/all and /armhf), I decided to make the setting an array variable.  However, this requires /bin/bash, so I changed that everywhere.  It would probably be good to make the other variables arrays as well, but I didn't need that, so I didn't do it.

"allow greater version of debootstrap" fixes the equality check of debootstrap; it also changes the generation of the number, because I think cut is simpler than awk, but that part shouldn't be required for it to work.

"workarounds for unconfigurable settings" contains three parts; you may not want to include them in this form.

The first part disables cape_universal=enable, because I don't want it; it would be good if this could be configured with a variable.

The second part writes the content of DISABLE_ETH into /etc/network/interfaces if it is set.  This way I can set eth0 up in a different way than the default (by setting it to a value that includes newlines).  The reason I need this is that the file is created after the chroot_after_hook is run, so I have no other way to change it; the proper fix would be to create it before that hook, so it can be edited or replaced from the hook script.

Finally, it adds auto and allow-hotplug to usb0 and removes the default gateway from it.  I think this would be good by default.  If the file is created before the hook, I can also fix it in my build from the hook script, so then we can agree to disagree on that.