### PR TITLE
disable enable_uboot_cape_universal

### DIFF
--- a/tools/setup_sdcard.sh
+++ b/tools/setup_sdcard.sh
@@ -1322,7 +1322,7 @@ populate_rootfs () {
 			fi
 			echo "###" >> ${wfile}
 			echo "###Cape Universal Enable" >> ${wfile}
-			if [ "x${uboot_cape_overlays}" = "xenable" ] ; then
+			if [ "x${uboot_cape_overlays}" = "xenable" ] && [ "x${enable_cape_universal}" = "xenable" ] ; then
 				echo "enable_uboot_cape_universal=1" >> ${wfile}
 			else
 				echo "#enable_uboot_cape_universal=1" >> ${wfile}


### PR DESCRIPTION
Disable `enable_uboot_cape_universal` if `enable_cape_universal` is not enabled

I needed this to be able to properly operate the PRU