### PR TITLE
add chroot_custom_setup_sdcard define

### DIFF
--- a/scripts/chroot.sh
+++ b/scripts/chroot.sh
@@ -1469,7 +1469,11 @@ chroot_umount
 
 if [ "x${chroot_COPY_SETUP_SDCARD}" = "xenable" ] ; then
 	echo "Log: copying setup_sdcard.sh related files"
-	sudo cp "${DIR}/tools/setup_sdcard.sh" "${DIR}/deploy/${export_filename}/"
+        if [ "x${chroot_custom_setup_sdcard}" = "x" ] ; then
+                sudo cp "${DIR}/tools/setup_sdcard.sh" "${DIR}/deploy/${export_filename}/"
+        else
+                sudo cp "${DIR}/tools/${chroot_custom_setup_sdcard}" "${DIR}/deploy/${export_filename}"
+        fi
 	sudo mkdir -p "${DIR}/deploy/${export_filename}/hwpack/"
 	sudo cp "${DIR}"/tools/hwpack/*.conf "${DIR}/deploy/${export_filename}/hwpack/"
 


### PR DESCRIPTION
Using the non-standard bealgebone black debian system, you can repartition your partitions using the stm32mp1_setup_sdcard, but you can use it on other devices more conveniently.
eg,chroot_custom_setup_sdcard="stm32mp1_setup_sdcard.sh"