### PR TITLE
bb.org:configs: add latest libiio package

### DIFF
--- a/configs/bb.org-debian-stretch-iot-grove-kit-v4.14.conf
+++ b/configs/bb.org-debian-stretch-iot-grove-kit-v4.14.conf
@@ -116,6 +116,7 @@ deb_additional_pkgs="	\
 	python3-pyaudio \
 	python3-tqdm \
 	portaudio19-dev \
+	python3-evdev \
 "
 
 ##

--- a/configs/bb.org-debian-stretch-iot-grove-kit-v4.14.conf
+++ b/configs/bb.org-debian-stretch-iot-grove-kit-v4.14.conf
@@ -49,7 +49,6 @@ deb_include="	\
 	iperf	\
 	iw	\
 	less	\
-	libiio-utils	\
 	libinline-files-perl	\
 	libncurses5-dev	\
 	libnss-mdns	\
@@ -199,4 +198,5 @@ repo_external_pkg_list="	\
 	python3-snowboy \
 	libatlas3-base \
 	libmagic1 \
+	libiio \
 "

--- a/configs/bb.org-debian-stretch-iot-grove-kit-v4.14.conf
+++ b/configs/bb.org-debian-stretch-iot-grove-kit-v4.14.conf
@@ -148,6 +148,7 @@ repo_rcnee_pkg_list="	\
 	firmware-am57xx-opencl-monitor	\
 	gpiod	\
 	linux-image-4.14.108-ti-r127	\
+	seeed-modules-4.14.108-ti-r127	\
 	moreutils	\
 	nodejs	\
 	overlayroot	\


### PR DESCRIPTION
There is no python wrapper version in the original debian source, so we can add it here after recompiling.
```
debian@beaglebone:/var/lib/cloud9/libiio$ dpkg --contents  /var/lib/cloud9/libiio/build/libiio-0.18.g3c7d514-Linux.deb
drwxr-xr-x root/root         0 2020-01-30 08:50 ./etc/
drwxr-xr-x root/root         0 2020-01-30 08:50 ./etc/avahi/
drwxr-xr-x root/root         0 2020-01-30 08:50 ./etc/avahi/services/
-rw-r--r-- root/root      1074 2020-01-30 08:12 ./etc/avahi/services/iio.service
drwxr-xr-x root/root         0 2020-01-30 08:50 ./lib/
drwxr-xr-x root/root         0 2020-01-30 08:50 ./lib/udev/
drwxr-xr-x root/root         0 2020-01-30 08:50 ./lib/udev/rules.d/
-rw-r--r-- root/root       121 2020-01-30 08:49 ./lib/udev/rules.d/90-libiio.rules
drwxr-xr-x root/root         0 2020-01-30 08:50 ./usr/
drwxr-xr-x root/root         0 2020-01-30 08:50 ./usr/bin/
-rwxr-xr-x root/root     27648 2020-01-30 08:50 ./usr/bin/iio_adi_xflow_check
-rwxr-xr-x root/root     46724 2020-01-30 08:49 ./usr/bin/iio_attr
-rwxr-xr-x root/root     18664 2020-01-30 08:49 ./usr/bin/iio_genxml
-rwxr-xr-x root/root     33464 2020-01-30 08:49 ./usr/bin/iio_info
-rwxr-xr-x root/root     32152 2020-01-30 08:49 ./usr/bin/iio_readdev
-rwxr-xr-x root/root     14008 2020-01-30 08:50 ./usr/bin/iio_reg
-rwxr-xr-x root/root     32304 2020-01-30 08:50 ./usr/bin/iio_writedev
drwxr-xr-x root/root         0 2020-01-30 08:50 ./usr/include/
-rw-r--r-- root/root     72221 2020-01-30 08:12 ./usr/include/iio.h
drwxr-xr-x root/root         0 2020-01-30 08:50 ./usr/lib/
drwxr-xr-x root/root         0 2020-01-30 08:50 ./usr/lib/arm-linux-gnueabihf/
lrwxrwxrwx root/root         0 2020-01-30 08:50 ./usr/lib/arm-linux-gnueabihf/libiio.so -> libiio.so.0
lrwxrwxrwx root/root         0 2020-01-30 08:50 ./usr/lib/arm-linux-gnueabihf/libiio.so.0 -> libiio.so.0.18
-rw-r--r-- root/root    365596 2020-01-30 08:49 ./usr/lib/arm-linux-gnueabihf/libiio.so.0.18
drwxr-xr-x root/root         0 2020-01-30 08:50 ./usr/lib/arm-linux-gnueabihf/pkgconfig/
-rw-r--r-- root/root       240 2020-01-30 08:48 ./usr/lib/arm-linux-gnueabihf/pkgconfig/libiio.pc
drwxr-xr-x root/root         0 2020-01-30 08:50 ./usr/lib/python3.5/
drwxr-xr-x root/root         0 2020-01-30 08:50 ./usr/lib/python3.5/site-packages/
drwxr-xr-x root/root         0 2020-01-30 08:50 ./usr/lib/python3.5/site-packages/__pycache__/
-rw-r--r-- root/root     30947 2020-01-30 08:50 ./usr/lib/python3.5/site-packages/__pycache__/iio.cpython-35.pyc
-rw-r--r-- root/root     28109 2020-01-30 08:48 ./usr/lib/python3.5/site-packages/iio.py
-rw-r--r-- root/root       247 2020-01-30 08:50 ./usr/lib/python3.5/site-packages/libiio-0.18-py3.5.egg-info
drwxr-xr-x root/root         0 2020-01-30 08:50 ./usr/sbin/
-rwxr-xr-x root/root    184148 2020-01-30 08:50 ./usr/sbin/iiod
```