### PR TITLE
fix: chroot.sh may not complete successfully

### DIFF
--- a/scripts/chroot.sh
+++ b/scripts/chroot.sh
@@ -1577,7 +1577,7 @@ fi
 if [ "x${chroot_directory}" = "xenable" ]; then
 	echo "Log: moving rootfs to directory: [${deb_arch}-rootfs-${deb_distribution}-${deb_codename}]"
 	sudo mv -v "${tempdir}" "${DIR}/deploy/${export_filename}/${deb_arch}-rootfs-${deb_distribution}-${deb_codename}"
-	du -h --max-depth=0 "${DIR}/deploy/${export_filename}/${deb_arch}-rootfs-${deb_distribution}-${deb_codename}"
+	sudo du -h --max-depth=0 "${DIR}/deploy/${export_filename}/${deb_arch}-rootfs-${deb_distribution}-${deb_codename}"
 else
 	cd "${tempdir}" || true
 	echo "Log: packaging rootfs: [${deb_arch}-rootfs-${deb_distribution}-${deb_codename}.tar]"


### PR DESCRIPTION
If the configuration includes chroot_directory="enable" then chroot.sh will fail when du cannot traverse restricted directories, which failure will cascade up the script hierarchy.