### PR TITLE
Enable strict mode in daily-debian-arm64 script

### DIFF
--- a/ci/daily-debian-arm64-13-base-v6.6-ti-am62.sh
+++ b/ci/daily-debian-arm64-13-base-v6.6-ti-am62.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 export apt_proxy=192.168.1.10:3142/
 


### PR DESCRIPTION
Updated the PR to only add set -euo pipefail for stricter error handling. No functional or behavior changes intended beyond safer script execution.